### PR TITLE
covid bootcamp pages removed from menu

### DIFF
--- a/src/components/menu/index.js
+++ b/src/components/menu/index.js
@@ -50,20 +50,11 @@ class MainMenu extends React.Component {
             key: "printed_archives",
           },
           {
-            link: "archives/covid_boot_camp",
-            title: "COVID Boot Camp",
-            key: "covid_boot_camp",
-          },
-          {
-            link: "archives/bootcamp_for_parents",
-            title: "Boot Camp for Parents",
-            key: "bootcamp_for_parents",
-          },
-          {
             link: "archives/scientific_studies",
             title: "Scientific Studies",
             key: "scientific_studies",
           },
+        
         ],
       },
       {


### PR DESCRIPTION
Removed "COVID BOOT CAMP" and "BOOT CAMP FOR PARENTS" pages from Archives dropdown